### PR TITLE
Allow new lines when pulling children

### DIFF
--- a/lib/simple_xml/xml_node.ex
+++ b/lib/simple_xml/xml_node.ex
@@ -135,11 +135,18 @@ defmodule SimpleXml.XmlNode do
       {:error, {:no_children_found, ["bar"]}}
 
   """
-  @spec children(xml_node()) :: {:ok, [String.t() | xml_node()]}
-  def children({_node, _attrs, [head | _tail] = children}) when is_binary(head),
-    do: {:error, {:no_children_found, children}}
-
-  def children({_node, _attrs, children}) when is_list(children), do: {:ok, children}
+  @spec children(xml_node()) ::
+          {:ok, [String.t() | xml_node()]}
+          | {:error, {:no_children_found, [String.t() | xml_node()]}}
+  def children({_node, _attrs, children}) do
+    children
+    |> Enum.reject(&(is_binary(&1) && String.trim(&1) == ""))
+    |> case do
+      [] -> {:error, {:no_children_found, children}}
+      [head | _tail] when is_binary(head) -> {:error, {:no_children_found, children}}
+      children -> {:ok, children}
+    end
+  end
 
   @doc """
   Returns all children that match the given child_name filter.  Filtering matches that of

--- a/test/xml_node_test.exs
+++ b/test/xml_node_test.exs
@@ -1,4 +1,40 @@
 defmodule XmlNodeTest do
   use ExUnit.Case
   doctest SimpleXml.XmlNode
+
+  describe "children/1" do
+    test "returns the children of doc with new lines" do
+      doc = """
+      <root>
+        <child1>value1</child1>
+        <child2>value2</child2>
+      </root>
+      """
+
+      {:ok, root} = SimpleXml.parse(doc)
+
+      assert SimpleXml.XmlNode.children(root) ==
+               {:ok,
+                [
+                  {"child1", [], ["value1"]},
+                  {"child2", [], ["value2"]}
+                ]}
+    end
+  end
+
+  describe "children/2" do
+    test "finds a child by name when doc has new lines" do
+      doc = """
+      <root>
+        <child1>value1</child1>
+        <child2>value2</child2>
+      </root>
+      """
+
+      {:ok, root} = SimpleXml.parse(doc)
+
+      assert SimpleXml.XmlNode.children(root, "child2") ==
+               [{"child2", [], ["value2"]}]
+    end
+  end
 end


### PR DESCRIPTION
When an XML document has new lines, it contains children that are "blank" text nodes. These nodes contain a combination of new lines and whitespace. If one of these nodes is present as the first child, it assumes that the children contain text.

Instead, ignore any nodes that are whitespace only.